### PR TITLE
Correct error message with ansible 2.3 "with_dict expects a dict"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,5 +11,5 @@
 
 - name: updating firewall rules
   firewalld: port={{item.value.port}}/{{item.value.protocol}} permanent={{item.value.permanent}} state={{item.value.state }} zone={{item.value.zone}}
-  with_dict: firewalld_rules
+  with_dict: "{{firewalld_rules}}"
   notify: restart firewalld


### PR DESCRIPTION
On Centos 7.3 with Ansible 2.3 from EPEL:

TASK [beardyjay.firewalld : updating firewall rules] ***************************************************************** 
fatal: [localhost]: FAILED! => {"failed": true, "msg": "with_dict expects a dict"}

It's seems that it is coming from [syntax shift in  Ansible](https://github.com/ansible/ansible/issues/17636)
